### PR TITLE
[API-633] Clean Up Request Log Files

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -55,6 +55,7 @@ function createRestifyLogger (server, options) {
 		// we prefix with date to make it easier to sort logs by timestamp
 		var name = 'request-' + req.getId(),
 			logname = path.join(logDir, name + '.log'),
+			logstream = fs.createWriteStream(logname),
 			log = bunyan.createLogger({
 				name: name,
 				serializers: {
@@ -64,11 +65,11 @@ function createRestifyLogger (server, options) {
 				streams: [
 					{
 						level: 'trace',
-						path: logname
+						stream: logstream
 					},
 					{
 						level: options && options.level || 'info',
-						type:'raw',
+						type: 'raw',
 						stream: consoleLogger
 					}
 				]
@@ -78,7 +79,9 @@ function createRestifyLogger (server, options) {
 		req.log = log;
 		req.started = process.hrtime();
 		req.log.logname = logname;
+		req.logstream = logstream;
 		req.log.name = name;
+		req.cleanStream = cleanStream;
 
 		next();
 	});
@@ -93,7 +96,7 @@ function createRestifyLogger (server, options) {
 		// see if we've already calculated the duration and if so, use it
 		var duration = req.duration;
 		if (!duration) {
-			// otherwise we need to calculated
+			// otherwise we need to calculate it
 			var time = process.hrtime(req.started);
 			duration = (time[0] / 1000) + (time[1] * 1.0e-6);
 			req.duration = duration;
@@ -113,26 +116,27 @@ function createRestifyLogger (server, options) {
 			};
 			fs.writeFileSync(req.log.logname + '.metadata', JSON.stringify(result));
 		}
-		// wait a little bit to let the after events to be processed before closing the stream
-		process.nextTick(function () {
-			setTimeout(function () {
-				// Bunyan doesn't close the file stream on its own. Dirty, dirty...
-				req.log.streams.forEach(function (ls) {
-					try {
-						if (ls.closeOnExit || !ls.raw) {
-							ls.stream.end();
-						}
-					}
-					catch (e) {
-					}
-				});
-			}, 500);
-		});
+		if (req.cleanStream) {
+			req.cleanStream();
+		}
 	});
 
 	server.log = serverLogger;
 
 	return serverLogger;
+}
+
+/**
+ * Cleans a req log stream up after a delayed period. This should be used as a method of a req, and called within the
+ * context of a req only (ie. req.cleanStream = cleanStream; req.cleanStream()).
+ */
+function cleanStream() {
+	var logStream = this.logstream;
+	this.logstream = this.cleanStream = null;
+	// wait a little bit to let other end events process before closing the stream
+	setTimeout(function () {
+		logStream.end();
+	}, 500);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "appc-logger",
-	"version": "1.0.29",
+	"version": "1.0.30",
 	"description": "Appcelerator Logger",
 	"main": "index.js",
 	"dependencies": {


### PR DESCRIPTION
This is a bit of a cleaner approach -- don't give Bunyan any file streams to handle. Then, expose a really simple method, "cleanStream" that will do a delayed close of the request stream. We'll use this at the end of the restify logger, plus we need to use it elsewhere.

https://jira.appcelerator.org/browse/API-633