### PR TITLE
[CLI-555] Mask password field in array

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -181,7 +181,17 @@ function specialObjectClone(obj, seen) {
 	if (type === 'function') { return null; }
 	if (type !== 'object') { return obj; }
 	if (obj instanceof Error) { return obj; }
-	if (Array.isArray(obj)) { return obj; }
+	if (Array.isArray(obj)) {
+		var maskFields = ['--password', '-password'];
+		newobj = null;
+		for (var i = 0, l = obj.length; i < l; ++i) {
+			if (maskFields.indexOf(obj[i]) > -1 && obj[++i]) {
+				if (newobj === null) { newobj = obj.slice(0); }
+				newobj[i] = '[HIDDEN]';
+			}
+		}
+		return newobj ? newobj : obj;
+	}
 
 	// we need to deal with circular references
 	seen = seen || [];


### PR DESCRIPTION
- Mask ```--password``` and ```-password``` fields contained in an array

###### DEPENDED ON BY
- [appc-cli/pull/147](https://github.com/appcelerator/appc-cli/pull/147)
- [appc-cli-titanium/pull/83](https://github.com/appcelerator/appc-cli-titanium/pull/83)

[JIRA Ticket](https://jira.appcelerator.org/browse/CLI-555)

###### NOTES
- Should we replace the password fields with ```********``` for parity?
- Currently the _appc-cli_ package.json contains ```"appc-logger": "1.0.30",``` should this be ```"appc-logger": "^1.0.30",```?
- I could not use ```appc-logger``` to mask
    - [appc-cli-titanium/plugins/new.js - line 403](https://github.com/appcelerator/appc-cli-titanium/blob/master/plugins/new.js#L403)
    - [appc-cli/lib/commands/login.js - line 287](https://github.com/appcelerator/appc-cli/blob/master/lib/commands/login.js#L287)