### PR TITLE
[NODEJS-2056] Integrate arrowcloud-logger into appc-logger for Arrow Cloud docker

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -10,6 +10,22 @@ var bunyan = require('bunyan'),
 	arrowCloudLogDir = '/ctlog';
 
 /**
+ * A bunyan serializer for req.route of express/restify
+ * @param  {Object} original route
+ * @return {Object} serialized route
+ */
+function routeSerializer(route) {
+	if (route && route.path) {
+		return {
+			path: route.path,
+			methods: route.methods,
+			method: route.method
+		};
+	}
+	return route;
+}
+
+/**
  * create a server logger (based on expressjs or restify),
  * and setup not only the main logger but also the request logger.
  * @param  {Object} server      instance of express app or restify server
@@ -53,7 +69,8 @@ function createHttpLogger(server, serviceType, options) {
 			name: serverName || 'requests',
 			serializers: {
 				req: bunyan.stdSerializers.req,
-				res: bunyan.stdSerializers.res
+				res: bunyan.stdSerializers.res,
+				route: routeSerializer
 			},
 			streams: [{
 				level: 'trace',
@@ -79,7 +96,8 @@ function createHttpLogger(server, serviceType, options) {
 					name: name,
 					serializers: {
 						req: bunyan.stdSerializers.req,
-						res: bunyan.stdSerializers.res
+						res: bunyan.stdSerializers.res,
+						route: routeSerializer
 					},
 					streams: [{
 						level: 'trace',
@@ -90,7 +108,7 @@ function createHttpLogger(server, serviceType, options) {
 						stream: consoleLogger
 					}]
 				});
-			log.info({req_id:req.requestId, req:req, res:resp, start:true, ignore:true}, 'start');
+			log.info({req_id:req.requestId, req:req, res:resp, route:req.route, start:true, ignore:true}, 'start');
 			req.log = log;
 			req.log.logname = logname;
 			req.logstream = logstream;
@@ -109,7 +127,7 @@ function createHttpLogger(server, serviceType, options) {
 	var logRequest = function (req, res) {
 		var responseTime = Math.round(req.duration);
 		if (req.log && req.log.logname) {
-			requestLogger.info({req_id:req.requestId, req:req, res:res, name:req.log.name, logname:req.log.logname, response_time: responseTime});
+			requestLogger.info({req_id:req.requestId, req:req, res:res, route:req.route, name:req.log.name, logname:req.log.logname, response_time: responseTime});
 			var result = {
 				url: req.url,
 				req_headers: req.headers,
@@ -121,7 +139,7 @@ function createHttpLogger(server, serviceType, options) {
 			};
 			fs.writeFileSync(req.log.logname + '.metadata', JSON.stringify(result));
 		} else {
-			requestLogger.info({req_id:req.requestId, req:req, res:res, response_time: responseTime});
+			requestLogger.info({req_id:req.requestId, req:req, res:res, route:req.route, response_time: responseTime});
 		}
 		if (req.cleanStream) {
 			req.cleanStream();

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,109 +2,114 @@ var bunyan = require('bunyan'),
 	_ = require('lodash'),
 	fs = require('fs'),
 	wrench = require('wrench'),
-	path = require('path');
+	path = require('path'),
+	responseTimeMiddleWare = require('response-time'),
+	uuid = require('uuid-v4'),
+	supportedHttpServices = ['restify', 'express', 'expressjs'],
+	arrowCloudHosted = process.env.NODE_ACS_URL ? true : false,
+	arrowCloudLogDir = '/ctlog';
 
 /**
- * create a restify server logger and setup not only the main
- * logger but also the request logger.
- *
- * @param  {Object} server - server
- * @param  {Object} options - options
+ * create a server logger (based on expressjs or restify),
+ * and setup not only the main logger but also the request logger.
+ * @param  {Object} server      instance of express app or restify server
+ * @param  {string} serviceType express, expressjs or restify
+ * @param  {Object} options     options: {name:'server/app name', level:'debug', afterEvent:'afterEvent', logSingleRequest:false}
+ * @return {Object}             server logger instance, with a request logger inside
  */
-function createRestifyLogger (server, options) {
-	var ConsoleLogger = require('./console');
-
-	var logs = options && options.logs || './logs';
-	if (!fs.existsSync(logs)) {
-		wrench.mkdirSyncRecursive(logs);
+function createHttpLogger(server, serviceType, options) {
+	if (typeof service === 'object') {
+		options = serviceType;
+		// default service type: express
+		serviceType = 'express';
 	}
 
-	var consoleLogger = new ConsoleLogger(options),
-		config = {
-			name: server.name || 'server',
+	if (supportedHttpServices.indexOf(serviceType) === -1) {
+		throw new Error('Wrong service type');
+	}
+
+	// variable to indicate if this app is hosted by Arrow Cloud
+	var ConsoleLogger = require('./console'),
+		logDir = options && options.logs || './logs';
+	if (!fs.existsSync(logDir)) {
+		wrench.mkdirSyncRecursive(logDir);
+	}
+
+	var serverName = server.name || (options && options.name),
+		consoleLogger = new ConsoleLogger(options),
+		serverLogger = bunyan.createLogger({
+			name: serverName || 'server',
 			serializers: {
 				req: bunyan.stdSerializers.req,
 				res: bunyan.stdSerializers.res
 			},
-			streams: [
-				{
-					level: options && options.level || 'info',
-					type: 'raw',
-					stream: consoleLogger
-				}
-			]
-		},
-		serverLogger = bunyan.createLogger(config),
-		logDir = logs,
+			streams: [{
+				level: options && options.level || 'info',
+				type: 'raw',
+				stream: consoleLogger
+			}]
+		}),
 		requestLogger = bunyan.createLogger({
-			name: server.name || 'requests',
+			name: serverName || 'requests',
 			serializers: {
 				req: bunyan.stdSerializers.req,
 				res: bunyan.stdSerializers.res
 			},
-			streams: [
-				{
-					level: 'trace',
-					path: path.join(logDir, 'requests.log')
-				}
-			]
+			streams: [{
+				level: 'trace',
+				path: path.join((arrowCloudHosted ? arrowCloudLogDir : logDir), 'requests.log')
+			}]
 		});
 
-	// for each request, create a request logger
+	server.log = serverLogger;
+
 	(server.pre || server.use).call(server, function (req, resp, next) {
-		// we prefix with date to make it easier to sort logs by timestamp
-		var name = 'request-' + req.getId(),
-			logname = path.join(logDir, name + '.log'),
-			logstream = fs.createWriteStream(logname),
-			log = bunyan.createLogger({
-				name: name,
-				serializers: {
-					req: bunyan.stdSerializers.req,
-					res: bunyan.stdSerializers.res
-				},
-				streams: [
-					{
+		req.requestId = (serviceType === 'restify' ? req.getId() : uuid());
+		if (serviceType === 'restify') {
+			// record timestamp if using restify framework
+			req.started = process.hrtime();
+		}
+
+		if (options && options.logSingleRequest) {
+			// we prefix with date to make it easier to sort logs by timestamp
+			var name = 'request-' + req.requestId,
+				logname = path.join(logDir, name + '.log'),
+				logstream = fs.createWriteStream(logname),
+				log = bunyan.createLogger({
+					name: name,
+					serializers: {
+						req: bunyan.stdSerializers.req,
+						res: bunyan.stdSerializers.res
+					},
+					streams: [{
 						level: 'trace',
 						stream: logstream
-					},
-					{
+					}, {
 						level: options && options.level || 'info',
 						type: 'raw',
 						stream: consoleLogger
-					}
-				]
-			});
-		// jscs:disable requireCamelCaseOrUpperCaseIdentifiers
-		log.info({req_id:req.getId(), req:req, res:resp, start:true, ignore:true}, 'start');
-		req.log = log;
-		req.started = process.hrtime();
-		req.log.logname = logname;
-		req.logstream = logstream;
-		req.log.name = name;
-		req.cleanStream = cleanStream;
+					}]
+				});
+			log.info({req_id:req.requestId, req:req, res:resp, start:true, ignore:true}, 'start');
+			req.log = log;
+			req.log.logname = logname;
+			req.logstream = logstream;
+			req.log.name = name;
+			req.cleanStream = cleanStream;
+		}
 
 		next();
 	});
 
-	// by default, listen for the server's 'after' event but also let the
-	// creator tell us to use a different event. this is nice when you have
-	// additional things you want to do before ending the logging (after the server might
-	// have sent the response) that you want to log or capture before ending
-	var afterEvent = options && options.afterEvent || 'after';
-
-	server.on(afterEvent, function (req, res) {
-		// see if we've already calculated the duration and if so, use it
-		var duration = req.duration;
-		if (!duration) {
-			// otherwise we need to calculate it
-			var time = process.hrtime(req.started);
-			duration = (time[0] / 1000) + (time[1] * 1.0e-6);
-			req.duration = duration;
-		}
-		// jscs:disable requireCamelCaseOrUpperCaseIdentifiers
-		requestLogger.info({res:res, req_id: req.getId(), req:req, name: req.log.name, logname: req.log.logname, duration: duration});
-		if (req.log.logname) {
-			// jscs:disable requireCamelCaseOrUpperCaseIdentifiers
+	/**
+	 * A function to log request into file
+	 * @param  {Object} req  Request
+	 * @param  {Object} res  Response
+	 */
+	var logRequest = function (req, res) {
+		var responseTime = Math.round(req.duration);
+		if (req.log && req.log.logname) {
+			requestLogger.info({req_id:req.requestId, req:req, res:res, name:req.log.name, logname:req.log.logname, response_time: responseTime});
 			var result = {
 				url: req.url,
 				req_headers: req.headers,
@@ -112,16 +117,46 @@ function createRestifyLogger (server, options) {
 				req_id: req.getId(),
 				name: req.log.name,
 				logname: req.log.logname,
-				duration: duration
+				response_time: responseTime
 			};
 			fs.writeFileSync(req.log.logname + '.metadata', JSON.stringify(result));
+		} else {
+			requestLogger.info({req_id:req.requestId, req:req, res:res, response_time: responseTime});
 		}
 		if (req.cleanStream) {
 			req.cleanStream();
 		}
-	});
+		if (!res._headerSent) {
+			res.setHeader('X-Response-time', req.duration + 'ms');
+		}
+	};
 
-	server.log = serverLogger;
+	if (serviceType === 'restify') {
+		// restify framework
+
+		// by default, listen for the server's 'after' event but also let the
+		// creator tell us to use a different event. this is nice when you have
+		// additional things you want to do before ending the logging (after the server might
+		// have sent the response) that you want to log or capture before ending
+		var afterEvent = options && options.afterEvent || 'after';
+		server.on(afterEvent, function (req, res) {
+			// see if we've already calculated the duration and if so, use it
+			var duration = req.duration;
+			if (!duration) {
+				// otherwise we need to calculate it
+				var time = process.hrtime(req.started);
+				duration = (time[0] / 1000) + (time[1] * 1.0e-6);
+				req.duration = duration;
+			}
+			logRequest(req, res);
+		});
+	} else {
+		// express framework
+		server.use(responseTimeMiddleWare(function (req, res, duration) {
+			req.duration = duration;
+			logRequest(req, res);
+		}));
+	}
 
 	return serverLogger;
 }
@@ -135,6 +170,28 @@ function cleanStream() {
 	this.logstream = this.cleanStream = null;
 	// wait a little bit to let other end events process before closing the stream
 	setTimeout(logStream.end.bind(logStream), 500);
+}
+
+/**
+ * create a restify server logger and setup not only the main
+ * logger but also the request logger.
+ *
+ * @param  {Object} server - restify server
+ * @param  {Object} options - options
+ */
+function createRestifyLogger(server, options) {
+	return createHttpLogger(server, 'restify', options);
+}
+
+/**
+ * create a expressjs logger and setup not only the main
+ * logger but also the request logger.
+ *
+ * @param  {Object} app - expressjs app
+ * @param  {Object} options - options
+ */
+function createExpressLogger(app, options) {
+	return createHttpLogger(app, 'express', options);
 }
 
 /**
@@ -252,6 +309,8 @@ function stripColors(str) {
 
 exports.createLogger = createDefaultLogger;
 exports.createDefaultLogger = createDefaultLogger;
+exports.createHttpLogger = createHttpLogger;
 exports.createRestifyLogger = createRestifyLogger;
+exports.createExpressLogger = createExpressLogger;
 exports.stripColors = stripColors;
 exports.specialObjectClone = specialObjectClone;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "appc-logger",
-	"version": "1.0.35",
+	"version": "1.1.0",
 	"description": "Appcelerator Logger",
 	"main": "index.js",
 	"dependencies": {
@@ -9,7 +9,10 @@
 		"chalk": "^0.5.1",
 		"fs-extra": "^0.11.1",
 		"lodash": "^2.4.1",
+		"on-headers": "^1.0.0",
 		"progress": "^1.1.8",
+		"response-time": "^2.3.1",
+		"uuid-v4": "^0.1.0",
 		"wrench": "^1.5.8"
 	},
 	"devDependencies": {

--- a/test/logger.js
+++ b/test/logger.js
@@ -68,7 +68,7 @@ describe('logger', function () {
 			server.listen(port, function (err) {
 				should(err).be.not.ok;
 
-				var logger = index.createRestifyLogger(server, {logs:tmpdir});
+				var logger = index.createRestifyLogger(server, {logs:tmpdir, logSingleRequest:true});
 				should(logger).be.an.object;
 				should(logger.info).be.a.function;
 
@@ -135,7 +135,7 @@ describe('logger', function () {
 					should(contents).have.property('logname', logfn);
 					should(contents).have.property('req_id', reqid);
 					should(contents).have.property('req_headers');
-					should(contents).have.property('duration');
+					should(contents).have.property('response_time');
 					should(contents).have.property('name', path.basename(fn).replace('.log', ''));
 
 					// now validate that our request is logged that points to our


### PR DESCRIPTION
## Ticket Information
***JIRA Ticket***
https://jira.appcelerator.org/browse/NODEJS-2056

***Description***
This PR is about to integrate features of arrowcloud-logger into appc-logger, to use appc-logger as fundamental logging system for new docker Arrow Cloud.

Via this pull request, we upgraded createRestifyLogger(), and currently we are able to support both Express and Restify framework. But since they deal with http services differently, we have to make slight optimization for each framework, so that we can take advantage of each of team, especially on how to get response time.

For now we can use ```Logger.createRestifyLogger(restifyServer, options);```, ```Logger.createExpressLogger(expressApp, options);``` or generic ```Logger.createHttpLogger(restifyServer, 'restify', options); Logger.createHttpLogger(expressApp, 'express', options);``` to take advantage of our inside request logger.

Also, a new option item "logSingleRequest" is added, to indicate if we want to log single request and its metadata ("request-uuid.log" and "request-uuid.log.metadata"). By default we start to set to false, since it may generate too many files on logs folder, which cannot be rotated easily.

## Suggested Test Steps
Test appc-logger independently:
\- Create a node.js app like https://gist.github.com/realpaul/47c164e7dc3169e6cd61
\- Install necessary node modules
\- Update node module appc-logger to include this pull request
\- Run node.js app with enabled expressjs and restify http services
\- Visit http://localhost:3000 and http://localhost:3001, and then see if logs/requests.log contains those http requests and responses

Test appc-logger within Arrow Cloud containers:
\- Use either single image or pre-production environment, and make sure this change as well as pull reqeusts of NODEJS-2056 of node-acs and acs-base-deployment repo have been well deployed
\- Make sure the following services are enabled by default
&nbsp;&nbsp;-- ENABLED_SERVICES=mongodb,td-agent:aggregator,node-acs-admin:index,node-acs-stratus,docker-container-mgr,haproxy-cfg-monitor:appc-haproxy-local,docker-registry
\- Create an Arrow Cloud app with free mode: ```acs new testApp --framework none```
\- With my code change of node-acs, an example code has been injected into acs command line like example mentioned above
\- mkdir node_modules, and copy appc-logger into node_modules
\- We may need to edit node_modules/appc-logger/package.json, to add a new field ```{"extraneous":true}``` into it, so that Arrow Cloud will not remove appc-logger, and install it on cloud side
\- Publish to cloud by using ```acs publish```, and make sure app can be published and deployed well
\- Make several requests to this app, and use ```acs accesslog``` to see if http requests have been well logged into our database
\- We can also check mongodb "access" database "access" collection, to see detailed access logs (request logs).