### PR TITLE
[API-888] Make acs logger backward compatible

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -243,7 +243,10 @@ function createDefaultLogger(options) {
 		});
 	}
 
-	return bunyan.createLogger(config);
+	var defaultLogger = bunyan.createLogger(config);
+	// Backward compatible with Arrow Cloud MVC framework
+	defaultLogger.setLevel = defaultLogger.level;
+	return defaultLogger;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "appc-logger",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "Appcelerator Logger",
 	"main": "index.js",
 	"dependencies": {


### PR DESCRIPTION
- Add a new function setLevel() to default logger and point to logger.level(), to make it backward compatible with old Arrow Cloud mvc framework