### PR TITLE
[API-915] appc-logger is lack of readable-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "appc-logger",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "Appcelerator Logger",
 	"main": "index.js",
 	"dependencies": {
@@ -11,6 +11,7 @@
 		"lodash": "^2.4.1",
 		"on-headers": "^1.0.0",
 		"progress": "^1.1.8",
+		"readable-stream": "^2.0.1",
 		"response-time": "^2.3.1",
 		"uuid-v4": "^0.1.0",
 		"wrench": "^1.5.8"


### PR DESCRIPTION
## Ticket Information
***JIRA Ticket***
https://jira.appcelerator.org/browse/API-915

***Description***
This PR is about to add missing node module readable-stream in package.json