### PR TITLE
[NODEJS-2157] filter out arrowPing.json in arrow-logger and fluentd on base container side

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -134,7 +134,7 @@ function createHttpLogger(server, serviceType, options) {
 	 */
 	var logRequest = function (req, res) {
 		var responseTime = Math.round(req.duration);
-		if (requestLogger && req.log && req.logname && (req.logmetadata === undefined || req.logmetadata)) {
+		if (requestLogger && req  && req.url && req.url !== '/arrowPing.json' && req.log && req.logname && (req.logmetadata === undefined || req.logmetadata)) {
 			requestLogger.info({req_id:req.requestId, req:req, res:res, route:req.route, name:req._logname, logname:req.logname, response_time: responseTime});
 			var result = {
 				url: req.url,
@@ -146,7 +146,7 @@ function createHttpLogger(server, serviceType, options) {
 				response_time: responseTime
 			};
 			fs.writeFileSync(req.logname + '.metadata', JSON.stringify(result));
-		} else if (requestLogger) {
+		} else if (requestLogger && req && req.url && req.url !== '/arrowPing.json') {
 			requestLogger.info({req_id:req.requestId, req:req, res:res, route:req.route, response_time: responseTime});
 		}
 		if (!res._headerSent) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "appc-logger",
-	"version": "1.1.6",
+	"version": "1.1.7",
 	"description": "Appcelerator Logger",
 	"main": "index.js",
 	"dependencies": {


### PR DESCRIPTION
## Ticket Information
***JIRA Ticket***
https://jira.appcelerator.org/browse/NODEJS-2157

***Description***
This PR is about to implement an additional feature to filter out those requests to /arrowPing.json, so that we will not have too much useless access log stored.