### PR TITLE
[API-945] Make acs-logger backward compatible with logger.setLevel('All')

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -251,8 +251,12 @@ function createDefaultLogger(options) {
 	}
 
 	var defaultLogger = bunyan.createLogger(config);
-	// Backward compatible with Arrow Cloud MVC framework
-	defaultLogger.setLevel = function(nameOrNum) {
+	/**
+	 * Set log level
+	 * Backward compatible with Arrow Cloud MVC framework
+	 * @param {Object} nameOrNum log level in string or number
+	 */
+	defaultLogger.setLevel = function (nameOrNum) {
 		var level = 'trace';
 		try {
 			level = bunyan.resolveLevel(nameOrNum);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -252,7 +252,13 @@ function createDefaultLogger(options) {
 
 	var defaultLogger = bunyan.createLogger(config);
 	// Backward compatible with Arrow Cloud MVC framework
-	defaultLogger.setLevel = defaultLogger.level;
+	defaultLogger.setLevel = function(nameOrNum) {
+		var level = 'trace';
+		try {
+			level = bunyan.resolveLevel(nameOrNum);
+		} catch (e) {}
+		return this.level(level);
+	};
 	return defaultLogger;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "appc-logger",
-	"version": "1.1.11",
+	"version": "1.1.12",
 	"description": "Appcelerator Logger",
 	"main": "index.js",
 	"dependencies": {


### PR DESCRIPTION
- Make sure user can use logger.setLevel('All')