### PR TITLE
[NODEJS-2199] Support multiple access log sources for Arrow 1.2+

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -46,12 +46,9 @@ function createHttpLogger(server, serviceType, options) {
 		logDir = arrowCloudHosted ? arrowCloudLogDir : (options && options.logs || './logs'),
 		skipRequestLog;
 
-	// if not hosted, create the directory. otherwise, if hosted, only write if the directory exists (backwards compat for pre-docker)
+	// if not hosted, create the directory.
 	if (!arrowCloudHosted && !fs.existsSync(logDir)) {
 		fs.mkdirs(logDir);
-	} else if (arrowCloudHosted && !fs.existsSync(path.join(logDir, 'requests.log'))) {
-		// ensure we can write to it. backwards compat issue
-		skipRequestLog = true;
 	}
 
 	// turn off if specified we don't want logging
@@ -86,7 +83,7 @@ function createHttpLogger(server, serviceType, options) {
 				period: '1d',
 				count: 1,
 				level: 'trace',
-				path: path.join(logDir, options.requestsLogFilename || 'requests.log')
+				path: path.join(logDir, options && options.requestsLogFilename || 'requests.log')
 			}]
 		});
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "appc-logger",
-	"version": "1.1.15",
+	"version": "1.1.16",
 	"description": "Appcelerator Logger",
 	"main": "index.js",
 	"dependencies": {


### PR DESCRIPTION
## Ticket Information
***JIRA Ticket***
https://jira.appcelerator.org/browse/NODEJS-2199

***Description***
This PR is about to improve Arrow Cloud to support multiple access log sources. Before that we only use /ctlog/requests.log inner container for access logs, but as Arrow 1.2 starts to support clustering, multiple workers cannot write into the same file.

Before this ticket we have the following links between base container and container:
- (BaseCT) ```/log/ctlog/<orgId>/<appId>/<appVersion>/<serverId>/<stackVersion>/console.log``` <==> (CT) ```/ctlog/console.log```
- (BaseCT) ```/log/ctlog/<orgId>/<appId>/<appVersion>/<serverId>/<stackVersion>/stats.log``` <==> (CT) ```/ctlog/stats.log```
- (BaseCT) ```/log/ctlog/<orgId>/<appId>/<appVersion>/<serverId>/<stackVersion>/requests.log``` <==> (CT) ```/ctlog/requests.log```

By this PR, requests.log will become:
- (BaseCT) ```/log/ctlog/<orgId>/<appId>/<appVersion>/<serverId>/<stackVersion>/requests/request-cluster-<clusterid>.log``` <==> (CT) ```/ctlog/request-cluster-<clusterid>.log```

On docker container manager side, we will mount two files (/ctlog/console.log and /ctlog/stats.log), as well as entire requests folder (/ctlog/requests). Fluentd will be changed accrodingly to read all log files inner ```/log/ctlog/<orgId>/<appId>/<appVersion>/<serverId>/<stackVersion>/requests```, and treat all of them as access log entries.

## Suggested Test Steps
\- Use either single image or pre-production environment, and make sure this change has been well deployed
\- Publish a default Arrow Cloud app with free framework
\- curl its entry point, and ```$ acs accesslog```