### PR TITLE
[API-1097] Make Sure /ctlog Is Writable + Fallback

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,6 +6,34 @@ var bunyan = require('bunyan'),
 	arrowCloudHosted = !!process.env.NODE_ACS_URL,
 	arrowCloudLogDir = '/ctlog';
 
+// Ensure that we can write to the cloud log dir.
+if (arrowCloudHosted && !isWritable(arrowCloudLogDir)) {
+	arrowCloudLogDir = path.join(process.env.HOME || process.env.USERPROFILE, 'ctlog');
+	if (!isWritable(arrowCloudLogDir)) {
+		arrowCloudLogDir = './logs';
+		isWritable(arrowCloudLogDir, true);
+	}
+}
+
+/**
+ * Checks if a directory is writable, returning a boolean or throwing an exception, depending on the arguments.
+ * @param dir The directory to check.
+ * @param throws Whether or not to throw an exception if the directory is not writable.
+ * @returns {boolean} Whether or not the directory is writable.
+ */
+function isWritable(dir, throws) {
+	if (throws) {
+		fs.accessSync(dir, fs.W_OK);
+		return true;
+	}
+	try {
+		fs.accessSync(dir, fs.W_OK);
+		return true;
+	} catch (exc) {
+		return false;
+	}
+}
+
 /**
  * A bunyan serializer for req.route of express/restify
  * @param  {Object} original route

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-logger",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "Appcelerator Logger",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
If we're going to try using the arrow cloud log dir, then make sure it is writable, and fall back to ~/ctlog if it isn't. Or, if that isn't either, try ./logs, and throw an exception straight away if it isn't.

https://jira.appcelerator.org/browse/API-1097