### PR TITLE
[API-1097] More Robust Log Dir Checks

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,34 +2,55 @@ var bunyan = require('bunyan'),
 	_ = require('lodash'),
 	fs = require('fs-extra'),
 	path = require('path'),
+	assert = require('assert'),
+	debug = require('debug')('appc:logger'),
 	supportedHttpServices = ['restify', 'express', 'expressjs'],
 	arrowCloudHosted = !!process.env.NODE_ACS_URL,
-	arrowCloudLogDir = '/ctlog';
+	arrowCloudLogDir = arrowCloudHosted && searchForArrowCloudLogDir();
 
-// Ensure that we can write to the cloud log dir.
-if (arrowCloudHosted && !isWritable(arrowCloudLogDir)) {
-	arrowCloudLogDir = path.join(process.env.HOME || process.env.USERPROFILE, 'ctlog');
-	if (!isWritable(arrowCloudLogDir)) {
-		arrowCloudLogDir = './logs';
-		isWritable(arrowCloudLogDir, true);
+/**
+ * Looks through the filesystem for a writable spot to which we can write the logs.
+ */
+function searchForArrowCloudLogDir() {
+	if (isWritable('/ctlog')) {
+		return '/ctlog';
 	}
+	if (process.env.HOME && isWritable(path.join(process.env.HOME, 'ctlog'))) {
+		return path.join(process.env.HOME, 'ctlog');
+	}
+	if (process.env.USERPROFILE && isWritable(path.join(process.env.USERPROFILE, 'ctlog'))) {
+		return path.join(process.env.USERPROFILE, 'ctlog');
+	}
+	if (isWritable('./logs')) {
+		return './logs';
+	}
+	throw new Error('No writable logging directory was found.');
 }
 
 /**
  * Checks if a directory is writable, returning a boolean or throwing an exception, depending on the arguments.
  * @param dir The directory to check.
- * @param throws Whether or not to throw an exception if the directory is not writable.
  * @returns {boolean} Whether or not the directory is writable.
  */
-function isWritable(dir, throws) {
-	if (throws) {
-		fs.accessSync(dir, fs.W_OK);
-		return true;
-	}
+function isWritable(dir) {
+	debug('checking if ' + dir + ' is writable');
 	try {
-		fs.accessSync(dir, fs.W_OK);
+		if (!fs.existsSync(dir)) {
+			debug(' - it does not exist yet, attempting to create it');
+			fs.mkdirSync(dir);
+		}
+		if (fs.accessSync) {
+			fs.accessSync(dir, fs.W_OK);
+		} else {
+			debug(' - fs.accessSync is not available, falling back to manual write detection');
+			fs.writeFileSync(path.join(dir, '.foo'), 'foo');
+			assert.equal(fs.readFileSync(path.join(dir, '.foo'), 'UTF-8'), 'foo');
+			fs.unlinkSync(path.join(dir, '.foo'));
+		}
+		debug(' - yes, it is writable');
 		return true;
 	} catch (exc) {
+		debug(' - no, it is not writable: ', exc);
 		return false;
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,49 +1,50 @@
 {
-  "name": "appc-logger",
-  "version": "1.1.20",
-  "description": "Appcelerator Logger",
-  "main": "index.js",
-  "dependencies": {
-    "async": "^1.4.0",
-    "bunyan": "^1.5.1",
-    "chalk": "^1.1.0",
-    "fs-extra": "^0.22.1",
-    "lodash": "^3.10.0",
-    "readable-stream": "^2.0.1",
-    "response-time": "^2.3.1",
-    "uuid-v4": "^0.1.0"
-  },
-  "devDependencies": {
-    "express": "^4.13.3",
-    "grunt": "^0.4.5",
-    "grunt-appc-js": "^1.0.0",
-    "grunt-contrib-clean": "^0.6.0",
-    "grunt-mocha-test": "^0.12.0",
-    "istanbul": "^0.3.2",
-    "mocha": "^2.2.5",
-    "request": "^2.61.0",
-    "should": "^7.0.2"
-  },
-  "scripts": {
-    "test": "grunt"
-  },
-  "bugs": {
-    "url": "https://jira.appcelerator.org/browse/API"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:appcelerator/appc-logger.git"
-  },
-  "keywords": [
-    "appcelerator",
-    "logger",
-    "appc-client",
-    "appc-jira-cli"
-  ],
-  "author": "Jeff Haynie",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/appcelerator/appc-logger/issues"
-  },
-  "homepage": "https://github.com/appcelerator/appc-logger"
+	"name": "appc-logger",
+	"version": "1.1.21",
+	"description": "Appcelerator Logger",
+	"main": "index.js",
+	"dependencies": {
+		"async": "^1.5.0",
+		"bunyan": "^1.5.1",
+		"chalk": "^1.1.1",
+		"debug": "^2.2.0",
+		"fs-extra": "^0.26.0",
+		"lodash": "^3.10.1",
+		"readable-stream": "^2.0.3",
+		"response-time": "^2.3.1",
+		"uuid-v4": "^0.1.0"
+	},
+	"devDependencies": {
+		"express": "^4.13.3",
+		"grunt": "^0.4.5",
+		"grunt-appc-js": "^1.0.0",
+		"grunt-contrib-clean": "^0.6.0",
+		"grunt-mocha-test": "^0.12.0",
+		"istanbul": "^0.3.2",
+		"mocha": "^2.2.5",
+		"request": "^2.61.0",
+		"should": "^7.0.2"
+	},
+	"scripts": {
+		"test": "grunt"
+	},
+	"bugs": {
+		"url": "https://jira.appcelerator.org/browse/API"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git@github.com:appcelerator/appc-logger.git"
+	},
+	"keywords": [
+		"appcelerator",
+		"logger",
+		"appc-client",
+		"appc-jira-cli"
+	],
+	"author": "Jeff Haynie",
+	"license": "Apache-2.0",
+	"bugs": {
+		"url": "https://github.com/appcelerator/appc-logger/issues"
+	},
+	"homepage": "https://github.com/appcelerator/appc-logger"
 }


### PR DESCRIPTION
I've also added the debug module, so if you run with the prefix `DEBUG=appc:logger` you'll see it searching the directories, and logging errors as it hits them. It will also attempt to create the necessary directories, if they do not exist.

https://jira.appcelerator.org/browse/API-1097