### PR TITLE
RDPP-891: ADI analytics logging should only contain api routes

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -264,7 +264,7 @@ function createHttpLogger(server, serviceType, options) {
 		var isInWhiteList = false;
 		options.adiWhitelist.forEach(function (route) {
 			if (url.substr(0, route.length) === route) {
-				isInWhiteList =true;
+				isInWhiteList = true;
 			}
 		});
 		return isInWhiteList;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -261,7 +261,7 @@ function createHttpLogger(server, serviceType, options) {
 	 * @return {boolean}     Is the URL in the whitelist
 	 */
 	function isWhitelisted(url) {
-		return _.some(options.adiWhitelist, function(route){
+		return _.some(options.adiWhitelist, function (route) {
 			return url.substr(0, route.length) === route;
 		});
 	}

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -261,13 +261,9 @@ function createHttpLogger(server, serviceType, options) {
 	 * @return {boolean}     Is the URL in the whitelist
 	 */
 	function isWhitelisted(url) {
-		var isInWhiteList = false;
-		options.adiWhitelist.forEach(function (route) {
-			if (url.substr(0, route.length) === route) {
-				isInWhiteList = true;
-			}
+		return _.some(options.adiWhitelist, function(route){
+			return url.substr(0, route.length) === route;
 		});
-		return isInWhiteList;
 	}
 
 	/**

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -78,7 +78,7 @@ function routeSerializer(route) {
  * and setup not only the main logger but also the request logger.
  * @param  {Object} server      instance of express app or restify server
  * @param  {string} serviceType express, expressjs or restify
- * @param  {Object} options     options: {name:'server/app name', level:'debug', afterEvent:'afterEvent', logSingleRequest:false, adiLogging: false, adiWhitelist: []}
+ * @param  {Object} options     options: {name:'server/app name', level:'debug', afterEvent:'afterEvent', logSingleRequest:false, adiLogging: false, adiPathFilter: []}
  * @return {Object}             server logger instance, with a request logger inside
  */
 function createHttpLogger(server, serviceType, options) {
@@ -107,8 +107,8 @@ function createHttpLogger(server, serviceType, options) {
 		skipRequestLog = true;
 	}
 
-	if (options.adiWhitelist === undefined) {
-		options.adiWhitelist = [];
+	if (options.adiPathFilter === undefined) {
+		options.adiPathFilter = [];
 	}
 
 	var serverName = server.name || (options && options.name),
@@ -261,7 +261,7 @@ function createHttpLogger(server, serviceType, options) {
 	 * @return {boolean}     Is the URL in the whitelist
 	 */
 	function isWhitelisted(url) {
-		return _.some(options.adiWhitelist, function (route) {
+		return _.some(options.adiPathFilter, function (route) {
 			return url.substr(0, route.length) === route;
 		});
 	}

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -78,7 +78,7 @@ function routeSerializer(route) {
  * and setup not only the main logger but also the request logger.
  * @param  {Object} server      instance of express app or restify server
  * @param  {string} serviceType express, expressjs or restify
- * @param  {Object} options     options: {name:'server/app name', level:'debug', afterEvent:'afterEvent', logSingleRequest:false, adiLogging: false}
+ * @param  {Object} options     options: {name:'server/app name', level:'debug', afterEvent:'afterEvent', logSingleRequest:false, adiLogging: false, adiWhitelist: []}
  * @return {Object}             server logger instance, with a request logger inside
  */
 function createHttpLogger(server, serviceType, options) {
@@ -105,6 +105,10 @@ function createHttpLogger(server, serviceType, options) {
 	// turn off if specified we don't want logging
 	if (!arrowCloudHosted && options && !options.logSingleRequest) {
 		skipRequestLog = true;
+	}
+
+	if (options.adiWhitelist === undefined) {
+		options.adiWhitelist = [];
 	}
 
 	var serverName = server.name || (options && options.name),
@@ -252,6 +256,21 @@ function createHttpLogger(server, serviceType, options) {
 	}
 
 	/**
+	 * Determine whether a certain URL is whitelisted based off the prefix
+	 * @param  {string}  url URL to check
+	 * @return {boolean}     Is the URL in the whitelist
+	 */
+	function isWhitelisted(url) {
+		var isInWhiteList = false;
+		options.adiWhitelist.forEach(function (route) {
+			if (url.substr(0, route.length) === route) {
+				isInWhiteList =true;
+			}
+		});
+		return isInWhiteList;
+	}
+
+	/**
 	 * A function to log request into file
 	 * @param  {Object} req  Request
 	 * @param  {Object} res  Response
@@ -259,7 +278,7 @@ function createHttpLogger(server, serviceType, options) {
 	function logRequest(req, res) {
 		var responseTime = Math.round(req.duration),
 			shouldLogRequest = requestLogger && req && req.url && req.url !== '/arrowPing.json',
-			shouldADILog = options.adiLogging && adiLogger && req && req.url && req.url !== '/arrowPing.json',
+			shouldADILog = options.adiLogging && adiLogger && req && req.url && isWhitelisted(req.url),
 			time = new Date().getTime(),
 			uri = (req.route && req.route.path) || (req.url && req.url.split('?')[0]),
 			port = getPort(req);

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,6 +1,7 @@
 // jscs:disable jsDoc
 // jshint -W079
-var should = require('should'),
+var async = require('async'),
+	should = require('should'),
 	index = require('../'),
 	_util = require('./_util'),
 	_console = new (require('./_console'))(),
@@ -438,67 +439,73 @@ describe('ADI logging', function () {
 
 	it('RDPP-644: status is "success" 1xx, 2xx, 3xx status codes', function (callback) {
 		var app = express();
+		var logPath = path.join(tmpdir, 'adi-analytics.log');
 		_util.findRandomPort(function (err, port) {
 			should(err).be.not.ok;
 			should(port).be.a.number;
-			var server = app.listen(port, function (err) {
-				should(err).be.not.ok;
-				var loggerConfig = {
-					logs: tmpdir,
-					logSingleRequest: true,
-					adiLogging: true,
-					name: 'arrowTest',
-					adiWhitelist: ['/echo', '/hundred', '/twoHundred', '/threeHundred', '/fourHundred', '/fiveHundred']
-				};
-				var logger = index.createExpressLogger(app, loggerConfig);
-				app.use(function (req, resp, next) {
-					resp.set('request-id', req.requestId);
-					next();
-				});
-				app.get('/hundred', function (req, resp, next) {
-					resp.status(100).send();
-					next();
-				});
-				app.get('/twoHundred', function (req, resp, next) {
-					resp.status(204).send();
-					next();
-				});
-				app.get('/threeHundred', function (req, resp, next) {
-					resp.status(301).send();
-					next();
-				});
-				app.get('/fourHundred', function (req, resp, next) {
-					resp.status(404).send();
-					next();
-				});
-				app.get('/fiveHundred', function (req, resp, next) {
-					resp.status(500).send();
-					next();
-				});
-				request.get('http://127.0.0.1:' + port + '/hundred', function (err, res, body) {
-					should(err).not.be.ok;
-					var logPath = path.join(tmpdir, 'adi-analytics.log');
-					should(fs.existsSync(logPath)).be.true;
-				});
-				request.get('http://127.0.0.1:' + port + '/twoHundred', function (err, res, body) {
-					should(err).not.be.ok;
-					var logPath = path.join(tmpdir, 'adi-analytics.log');
-					should(fs.existsSync(logPath)).be.true;
-				});
-				request.get('http://127.0.0.1:' + port + '/threeHundred', function (err, res, body) {
-					should(err).not.be.ok;
-					var logPath = path.join(tmpdir, 'adi-analytics.log');
-					should(fs.existsSync(logPath)).be.true;
-				});
-				request.get('http://127.0.0.1:' + port + '/fourHundred', function (err, res, body) {
-					should(err).not.be.ok;
-					var logPath = path.join(tmpdir, 'adi-analytics.log');
-					should(fs.existsSync(logPath)).be.true;
-				});
-				request.get('http://127.0.0.1:' + port + '/fiveHundred', function (err, res, body) {
-					should(err).not.be.ok;
-					var logPath = path.join(tmpdir, 'adi-analytics.log');
-					should(fs.existsSync(logPath)).be.true;
+			async.series([
+				function (cb) {
+					var server = app.listen(port, function (err) {
+						should(err).be.not.ok;
+						var loggerConfig = {
+							logs: tmpdir,
+							logSingleRequest: true,
+							adiLogging: true,
+							name: 'arrowTest',
+							adiWhitelist: ['/echo', '/hundred', '/twoHundred', '/threeHundred', '/fourHundred', '/fiveHundred']
+						};
+						var logger = index.createExpressLogger(app, loggerConfig);
+						app.use(function (req, resp, next) {
+							resp.set('request-id', req.requestId);
+							next();
+						});
+						app.get('/hundred', function (req, resp, next) {
+							resp.status(100).send();
+							next();
+						});
+						app.get('/twoHundred', function (req, resp, next) {
+							resp.status(204).send();
+							next();
+						});
+						app.get('/threeHundred', function (req, resp, next) {
+							resp.status(301).send();
+							next();
+						});
+						app.get('/fourHundred', function (req, resp, next) {
+							resp.status(404).send();
+							next();
+						});
+						app.get('/fiveHundred', function (req, resp, next) {
+							resp.status(500).send();
+							next();
+						});
+						cb();
+					});
+				},
+				function (cb) {
+					request.get('http://127.0.0.1:' + port + '/hundred', function (err, res, body) {
+						should(err).not.be.ok;
+						should(fs.existsSync(logPath)).be.true;
+					});
+					request.get('http://127.0.0.1:' + port + '/twoHundred', function (err, res, body) {
+						should(err).not.be.ok;
+						should(fs.existsSync(logPath)).be.true;
+					});
+					request.get('http://127.0.0.1:' + port + '/threeHundred', function (err, res, body) {
+						should(err).not.be.ok;
+						should(fs.existsSync(logPath)).be.true;
+					});
+					request.get('http://127.0.0.1:' + port + '/fourHundred', function (err, res, body) {
+						should(err).not.be.ok;
+						should(fs.existsSync(logPath)).be.true;
+					});
+					request.get('http://127.0.0.1:' + port + '/fiveHundred', function (err, res, body) {
+						should(err).not.be.ok;
+						should(fs.existsSync(logPath)).be.true;
+						cb();
+					});
+				},
+				function () {
 					readFile(logPath, function (err, data) {
 						should(err).equal(null);
 						var logEntries = data.split('\n');
@@ -514,8 +521,8 @@ describe('ADI logging', function () {
 						should(fiveHundred.status).equal('failure');
 						callback();
 					});
-				});
-			});
+				}
+			]);
 		});
 	});
 

--- a/test/logger.js
+++ b/test/logger.js
@@ -504,25 +504,24 @@ describe('ADI logging', function () {
 						should(fs.existsSync(logPath)).be.true;
 						cb();
 					});
-				},
-				function () {
-					readFile(logPath, function (err, data) {
-						should(err).equal(null);
-						var logEntries = data.split('\n');
-						var hundred = JSON.parse(logEntries[0]);
-						var twoHundred = JSON.parse(logEntries[1]);
-						var threeHundred = JSON.parse(logEntries[2]);
-						var fourHundred = JSON.parse(logEntries[3]);
-						var fiveHundred = JSON.parse(logEntries[4]);
-						should(hundred.status).equal('success');
-						should(twoHundred.status).equal('success');
-						should(threeHundred.status).equal('success');
-						should(fourHundred.status).equal('failure');
-						should(fiveHundred.status).equal('failure');
-						callback();
-					});
 				}
-			]);
+			], function (err, results) {
+				readFile(logPath, function (err, data) {
+					should(err).equal(null);
+					var logEntries = data.split('\n');
+					var hundred = JSON.parse(logEntries[0]);
+					var twoHundred = JSON.parse(logEntries[1]);
+					var threeHundred = JSON.parse(logEntries[2]);
+					var fourHundred = JSON.parse(logEntries[3]);
+					var fiveHundred = JSON.parse(logEntries[4]);
+					should(hundred.status).equal('success');
+					should(twoHundred.status).equal('success');
+					should(threeHundred.status).equal('success');
+					should(fourHundred.status).equal('failure');
+					should(fiveHundred.status).equal('failure');
+					callback();
+				});
+			});
 		});
 	});
 

--- a/test/logger.js
+++ b/test/logger.js
@@ -200,7 +200,7 @@ describe('ADI logging', function () {
 					logSingleRequest: false,
 					adiLogging: true,
 					name: 'arrowTest',
-					adiWhitelist: ['/echo']
+					adiPathFilter: ['/echo']
 				};
 				var logger = index.createExpressLogger(app, loggerConfig);
 				app.use(function (req, resp, next) {
@@ -238,7 +238,7 @@ describe('ADI logging', function () {
 					logSingleRequest: false,
 					adiLogging: true,
 					name: 'arrowTest',
-					adiWhitelist: ['/echo']
+					adiPathFilter: ['/echo']
 				};
 				var logger = index.createExpressLogger(app, loggerConfig);
 				app.use(function (req, resp, next) {
@@ -277,7 +277,7 @@ describe('ADI logging', function () {
 					logSingleRequest: false,
 					adiLogging: true,
 					name: 'arrowTest',
-					adiWhitelist: ['/api']
+					adiPathFilter: ['/api']
 				};
 				var logger = index.createExpressLogger(app, loggerConfig);
 				app.use(function (req, resp, next) {
@@ -330,7 +330,7 @@ describe('ADI logging', function () {
 					logSingleRequest: true,
 					adiLogging: true,
 					name: 'arrowTest',
-					adiWhitelist: ['/echo']
+					adiPathFilter: ['/echo']
 				};
 				var logger = index.createExpressLogger(app, loggerConfig);
 				app.use(function (req, resp, next) {
@@ -368,7 +368,7 @@ describe('ADI logging', function () {
 					logSingleRequest: true,
 					adiLogging: true,
 					name: 'arrowTest',
-					adiWhitelist: ['/echo']
+					adiPathFilter: ['/echo']
 				};
 				var logger = index.createExpressLogger(app, loggerConfig);
 				app.use(function (req, resp, next) {
@@ -408,7 +408,7 @@ describe('ADI logging', function () {
 					logSingleRequest: true,
 					adiLogging: true,
 					name: 'arrowTest',
-					adiWhitelist: ['/echo']
+					adiPathFilter: ['/echo']
 				};
 				var logger = index.createExpressLogger(app, loggerConfig);
 				app.use(function (req, resp, next) {
@@ -450,7 +450,7 @@ describe('ADI logging', function () {
 					logSingleRequest: true,
 					adiLogging: true,
 					name: 'arrowTest',
-					adiWhitelist: ['/echo', '/hundred', '/twoHundred', '/threeHundred', '/fourHundred', '/fiveHundred']
+					adiPathFilter: ['/echo', '/hundred', '/twoHundred', '/threeHundred', '/fourHundred', '/fiveHundred']
 				};
 				var logger = index.createExpressLogger(app, loggerConfig);
 				app.use(function (req, resp, next) {
@@ -547,7 +547,7 @@ describe('ADI logging', function () {
 					logSingleRequest: true,
 					adiLogging: true,
 					name: 'arrowTest',
-					adiWhitelist: ['/echo']
+					adiPathFilter: ['/echo']
 				};
 				var logger = index.createExpressLogger(app, loggerConfig);
 				app.use(function (req, resp, next) {


### PR DESCRIPTION
[jira](https://techweb.axway.com/jira/browse/RDPP-891)

- Add adiWhitelist to options which is passed in from Arrow, defaults to empty Array if it is not passed in
- Update tests to have this
- Before updating the test the failures were happening in unexpected ways i.e test1 making test2 fail, moving the callback to inside the readFile functions stopped this 