### PR TITLE
WIP: RDPP-890: Update logged values

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -255,6 +255,16 @@ function createHttpLogger(server, serviceType, options) {
 	}
 
 	/**
+	 * derives the address from req.ip
+	 * @param  {Object} req express request object
+	 * @return {string}     string of the address
+	 */
+	function getRemoteAddress(req) {
+		var addr  = (req.ip || '').split(':');
+		return addr[addr.length - 1];
+	}
+
+	/**
 	 * A function to log request into file
 	 * @param  {Object} req  Request
 	 * @param  {Object} res  Response
@@ -265,7 +275,8 @@ function createHttpLogger(server, serviceType, options) {
 			shouldADILog = options.adiLogging && adiLogger && req && req.url && req.url !== '/arrowPing.json',
 			time = new Date().getTime(),
 			uri = (req.route && req.route.path) || (req.url && req.url.split('?')[0]),
-			localPort = getPort(req);
+			localPort = getPort(req),
+			remoteAddr = getRemoteAddress(req);
 
 		if (shouldLogRequest && req.log && req.logname && (req.logmetadata === undefined || req.logmetadata)) {
 			requestLogger.info({
@@ -331,8 +342,8 @@ function createHttpLogger(server, serviceType, options) {
 						wafStatus: 0,
 						bytesSent: parseInt(res.get('Content-Length'), 10) || null,
 						bytesReceived: parseInt(req.get('Content-Length'), 10) || null,
-						remoteName: req.hostname || '',
-						remoteAddr: req.ip || '',
+						remoteName: remoteAddr,
+						remoteAddr: remoteAddr,
 						localAddr: '',
 						remotePort: ((req.connection && req.connection.remotePort) || '').toString(),
 						localPort: '',

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -274,7 +274,7 @@ function createHttpLogger(server, serviceType, options) {
 			shouldLogRequest = requestLogger && req && req.url && req.url !== '/arrowPing.json',
 			shouldADILog = options.adiLogging && adiLogger && req && req.url && req.url !== '/arrowPing.json',
 			time = new Date().getTime(),
-			uri = (req.route && req.route.path) || (req.url && req.url.split('?')[0]),
+			uri = (req.route && req.route.path) || req.path || (req.url && req.url.split('?')[0]),
 			localPort = getPort(req),
 			remoteAddr = getRemoteAddress(req);
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -255,16 +255,6 @@ function createHttpLogger(server, serviceType, options) {
 	}
 
 	/**
-	 * derives the address from req.ip
-	 * @param  {Object} req express request object
-	 * @return {string}     string of the address
-	 */
-	function getRemoteAddress(req) {
-		var addr  = (req.ip || '').split(':');
-		return addr[addr.length - 1];
-	}
-
-	/**
 	 * A function to log request into file
 	 * @param  {Object} req  Request
 	 * @param  {Object} res  Response
@@ -275,8 +265,7 @@ function createHttpLogger(server, serviceType, options) {
 			shouldADILog = options.adiLogging && adiLogger && req && req.url && req.url !== '/arrowPing.json',
 			time = new Date().getTime(),
 			uri = (req.route && req.route.path) || req.path || (req.url && req.url.split('?')[0]),
-			localPort = getPort(req),
-			remoteAddr = getRemoteAddress(req);
+			localPort = getPort(req);
 
 		if (shouldLogRequest && req.log && req.logname && (req.logmetadata === undefined || req.logmetadata)) {
 			requestLogger.info({
@@ -342,10 +331,10 @@ function createHttpLogger(server, serviceType, options) {
 						wafStatus: 0,
 						bytesSent: parseInt(res.get('Content-Length'), 10) || null,
 						bytesReceived: parseInt(req.get('Content-Length'), 10) || null,
-						remoteName: remoteAddr,
-						remoteAddr: remoteAddr,
+						remoteName: '',
+						remoteAddr: '',
 						localAddr: '',
-						remotePort: ((req.connection && req.connection.remotePort) || '').toString(),
+						remotePort: '',
 						localPort: '',
 						sslsubject: null,
 						leg: 0,

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -246,12 +246,7 @@ function createHttpLogger(server, serviceType, options) {
 	 * @return {string}     string representation of request id
 	 */
 	function getCorrelationId(req) {
-		var splitName = req._logname && req._logname.split('request-');
-		if (splitName && splitName.length === 2) {
-			return splitName[1];
-		} else {
-			return null;
-		}
+		return req.requestId || null;
 	}
 
 	/**

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -209,6 +209,9 @@ function createHttpLogger(server, serviceType, options) {
 	 * @return {string}     string representation of port
 	 */
 	function getPort(req) {
+		if (req.connection && req.connection.localPort) {
+			return req.connection.localPort.toString();
+		}
 		var host = req.headers && req.headers.host;
 		var protocolSrc = 80;
 		if (host && ((host.match(/:/g) || []).length) === 1) {
@@ -262,7 +265,7 @@ function createHttpLogger(server, serviceType, options) {
 			shouldADILog = options.adiLogging && adiLogger && req && req.url && req.url !== '/arrowPing.json',
 			time = new Date().getTime(),
 			uri = (req.route && req.route.path) || (req.url && req.url.split('?')[0]),
-			port = getPort(req);
+			localPort = getPort(req);
 
 		if (shouldLogRequest && req.log && req.logname && (req.logmetadata === undefined || req.logmetadata)) {
 			requestLogger.info({
@@ -301,7 +304,7 @@ function createHttpLogger(server, serviceType, options) {
 				time: time,
 				path: uri,
 				protocol: req.protocol,
-				protocolSrc: port,
+				protocolSrc: localPort,
 				duration: responseTime,
 				status: getStatus(res),
 				serviceContexts: [
@@ -328,10 +331,10 @@ function createHttpLogger(server, serviceType, options) {
 						wafStatus: 0,
 						bytesSent: parseInt(res.get('Content-Length'), 10) || null,
 						bytesReceived: parseInt(req.get('Content-Length'), 10) || null,
-						remoteName: '',
-						remoteAddr: '',
+						remoteName: req.hostname || '',
+						remoteAddr: req.ip || '',
 						localAddr: '',
-						remotePort: '',
+						remotePort: ((req.connection && req.connection.remotePort) || '').toString(),
 						localPort: '',
 						sslsubject: null,
 						leg: 0,

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -342,7 +342,7 @@ function createHttpLogger(server, serviceType, options) {
 						duration: responseTime,
 						serviceName: uri,
 						subject: null,
-						operation: uri,
+						operation: req.method + ' - ' + uri,
 						type: req.protocol,
 						finalStatus: ''
 					}

--- a/test/_util.js
+++ b/test/_util.js
@@ -3,23 +3,27 @@ var fs = require('fs-extra'),
 		path = require('path'),
 		tmpdir = path.join(os.tmpdir(), 'appc-logger');
 
+/**
+ * create a temporary directory for use and return the path in the cb
+ */
 function getTempDir(cb) {
 	var dir = path.join(tmpdir, 'test-logger-' + Date.now());
-	fs.ensureDir(dir, function(err) {
+	fs.ensureDir(dir, function (err) {
 		if (err) {
 			console.error(err);
 		}
 		return cb(err, dir);
-	})
+	});
 }
 
+/**
+ * cleanup the created temporary directories
+ */
 function cleanupTempDirs(cb) {
-	console.log('clean up', tmpdir);
-	setTimeout(function() {
+	setTimeout(function () {
 		fs.remove(tmpdir, cb);
 	}, 9000);
 }
-
 
 /**
  * create a random port that is safe for listening

--- a/test/logger.js
+++ b/test/logger.js
@@ -33,7 +33,7 @@ function readFile (filePath, deleteFile, cb) {
 describe('logger', function () {
 
 	beforeEach(function (done) {
-		_util.getTempDir(function(err, dir) {
+		_util.getTempDir(function (err, dir) {
 			tmpdir = dir;
 			done();
 		});
@@ -118,7 +118,7 @@ describe('logger', function () {
 
 				request.get('http://127.0.0.1:' + port + '/echo', function (err, res, body) {
 					// 1 sec timeout gives it time to write the logs.
-					setTimeout(function() {
+					setTimeout(function () {
 						should(err).not.be.ok;
 						var obj = body && JSON.parse(body);
 						should(obj).be.an.object;
@@ -151,7 +151,6 @@ describe('logger', function () {
 						should(fs.existsSync(fn + '.metadata')).be.true;
 
 						var metadata = fs.readFileSync(fn + '.metadata').toString();
-						console.log(2, metadata);
 						contents = JSON.parse(metadata);
 						should(contents).be.an.object;
 						should(contents).have.property('logname', logfn);
@@ -174,7 +173,7 @@ describe('logger', function () {
 						should(contents).have.property('logname', logfn);
 						callback();
 					}, 1000);
-				})
+				});
 			});
 		});
 	});
@@ -183,7 +182,7 @@ describe('logger', function () {
 describe('ADI logging', function () {
 
 	beforeEach(function (done) {
-		_util.getTempDir(function(err, dir) {
+		_util.getTempDir(function (err, dir) {
 			tmpdir = dir;
 			done();
 		});

--- a/test/logger.js
+++ b/test/logger.js
@@ -523,7 +523,7 @@ describe('ADI logging', function () {
 				};
 				var logger = index.createExpressLogger(app, loggerConfig);
 				app.use(function (req, resp, next) {
-					req._logname = '';
+					req.requestId = '';
 					next();
 				});
 				app.get('/echo', function (req, resp, next) {


### PR DESCRIPTION
This PR is related to https://techweb.axway.com/jira/browse/RDPP-890
- Originally legs[0].remoteName, legs[0].remoteAddr, legs[0].remotePort were added to the logs. But they added little value and were difficult to discern. 
- We now log the canonical path as the URI if it is known to express otherwise we log the full unregistered path. 
- Operation is now: METHOD - URI
- Fixed an issue where the correlationId was not set when deployed to docker